### PR TITLE
Fix rss memory probe for Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ version = "0.1.0"
 dependencies = [
  "jemallocator",
  "libproc",
+ "probes",
  "serde",
  "serde_json",
  "simd-json",
@@ -181,6 +182,16 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "probes"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb02a28631f195f482c19529ec82bec8e4ffa2d96159e67eb1ae9f5c5c902d8"
+dependencies = [
+ "libc",
+ "time",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -268,6 +279,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,9 +315,9 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,15 @@ edition = "2021"
 [dependencies]
 serde = "1.0.130"
 serde_json = "1.0.69"
-libproc = "0.10.0"
 jemallocator = "0.3.2"
 simd-json = { version = "0.4.8", features = ["known-key"] }
+probes = "0.4.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+probes = "0.4.1"
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+libproc = "0.10.0"
 
 [profile.release]
 lto = "fat"


### PR DESCRIPTION
This will correct the reported memory utilization for the load time on Linux to bring it closer to the reported value by `time` with the "%M" format string.